### PR TITLE
fixed directory separator character

### DIFF
--- a/src/main/java/io/github/nanodankster/skriptnpc/SkriptNPC.java
+++ b/src/main/java/io/github/nanodankster/skriptnpc/SkriptNPC.java
@@ -69,7 +69,7 @@ public class SkriptNPC extends JavaPlugin {
                 getLogger().warning("Cannot create the plugin folder!");
             }
         }
-        File file = new File(getDataFolder() + "\\config.yml");
+        File file = new File(getDataFolder() + File.separator + "config.yml");
         if (!file.exists()) {
             try {
                 Files.copy(getResource("config.yml"),file.toPath());


### PR DESCRIPTION
To fix issue #5 , I changed the hard-coded slash in the file path for the config.yml to use java.io.File.separator instead.